### PR TITLE
Update method to determine node or browser version of less

### DIFF
--- a/src/less.js
+++ b/src/less.js
@@ -12,8 +12,9 @@ module.exports = new CSSPluginBase(function compile(style, address, opts) {
   var loader = this;
 
   // use a file path in Node and a URL in the browser
-  var filename = this.builder ? fromFileURL(address) : address,
-    lessPromise = this.builder ? System.import('./bundled_less/less.node.js', module.id) : System.import('./bundled_less/less.browser.js', module.id);
+  var useNode = typeof process === 'object' && typeof process.versions.node === 'string';
+  var filename = useNode ? fromFileURL(address) : address,
+    lessPromise = useNode ? System.import('./bundled_less/less.node.js', module.id) : System.import('./bundled_less/less.browser.js', module.id);
 
   return lessPromise
     .then(function (less) {


### PR DESCRIPTION
import node version of less based on process information rather than existence of builder
allows for plugin to be used with testing frameworks without mocking out a full dom environment

I have a React app that imports less files directly into component files. When running my tests, the plugin was choosing to use the browser version of less rather than the node version of less since I'm not using a builder in my tests. This allows me to use the plugin without having to mock out an entire browser environment.